### PR TITLE
IT flag decode fix, go 1.18 upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/gotracker/goaudiofile
 
-go 1.15
+go 1.18
 
 require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,1 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/music/tracked/it/flags.go
+++ b/music/tracked/it/flags.go
@@ -44,7 +44,7 @@ func (f IMPMFlags) IsLinearSlides() bool {
 
 // IsOldEffects returns true if old-style effects are enabled
 func (f IMPMFlags) IsOldEffects() bool {
-	return (f & IMPMFlagLinearSlides) != 0
+	return (f & IMPMFlagOldEffects) != 0
 }
 
 // IsEFGLinking returns true if effect E/F/G linking is enabled

--- a/music/tracked/mod/util_linux.go
+++ b/music/tracked/mod/util_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package mod

--- a/music/tracked/mod/util_win.go
+++ b/music/tracked/mod/util_win.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package mod


### PR DESCRIPTION
## Fixed or Changed
- Upgrade project to go 1.18
- Fix issue with IT flag decode for Old Effects
