### PR TITLE
Various things to make it possible to run on wasm and macOS

### DIFF
--- a/music/tracked/mod/util_notwindows.go
+++ b/music/tracked/mod/util_notwindows.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 package mod
 

--- a/music/tracked/xm/instheader.go
+++ b/music/tracked/xm/instheader.go
@@ -394,9 +394,9 @@ func readInstrumentHeader(r io.Reader) (*InstrumentHeader, error) {
 
 		// convert the sample in the background
 		if (s.Flags & SampleFlag16Bit) != 0 {
-			go convertSample16Bit(s.SampleData)
+			convertSample16Bit(s.SampleData)
 		} else {
-			go convertSample8Bit(s.SampleData)
+			convertSample8Bit(s.SampleData)
 		}
 	}
 	return ih, nil


### PR DESCRIPTION
Hello! 

I was trying to use your libraries in a project which runs in browsers and on macOS and stumbled upon two problems which I solved:

* Removed unsynchronized goroutine for converting samples - caused unpredictable behaviour on load
* Used BE16ToLE16 Linux implementation on all other platforms

This also makes gotracker usable on macOS (it only converts to file, but it's something!)